### PR TITLE
Fix mutable module attribute to be initialized in constructor

### DIFF
--- a/src/dropmqttapi/mqttapi.py
+++ b/src/dropmqttapi/mqttapi.py
@@ -11,7 +11,11 @@ _LOGGER = logging.getLogger(__name__)
 class DropAPI:
     """Class for parsing MQTT data messages for DROP devices."""
 
-    _data_cache: dict[str, Any] = {}
+    _data_cache: dict[str, Any]
+    
+    def __init__(self) -> None:
+        """Initialize the DROP API."""
+        self._data_cache = {}
 
     def parse_drop_message(
         self, topic: str, payload: str | bytes, qos: int, retain: bool


### PR DESCRIPTION
### Problem

The `_data_cache` property is of a mutable type and should not be initialized at module level.
The current code causes that the cache is passed through to other entities that might have different values.
Also it will fail unit tests, as the initial values are unpredictable.

See: https://github.com/home-assistant/core/pull/106965
A new release of the DROP API is needed that fixes this issue.

### Proposal

Initialize the `_data_cache` property using a constructor. This will ensure that for every device that is initialized will have its own cache, and not a shared one. This is needed because some properties can exist on multiple devices and could give a wrong result when cached global.